### PR TITLE
[INFRA] Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/suggestion-from-bids-2-0-doc.md
+++ b/.github/ISSUE_TEMPLATE/suggestion-from-bids-2-0-doc.md
@@ -7,9 +7,12 @@ assignees: ''
 
 ---
 
-# Write the content of the suggestion here.
-# Add comments to the suggestion as separate comments in the issue thread.
+<!--
+Write the content of the suggestion here.
+Add comments to the suggestion as separate comments in the issue thread.
+-->
 
-
-# List the original authors' GitHub handles or names here.
+<!--
+List the original authors' GitHub handles or names here.
+-->
 **Original authors**:

--- a/.github/ISSUE_TEMPLATE/suggestion-from-bids-2-0-doc.md
+++ b/.github/ISSUE_TEMPLATE/suggestion-from-bids-2-0-doc.md
@@ -1,0 +1,15 @@
+---
+name: Suggestion from BIDS 2.0 Doc
+about: Existing suggestions from the BIDS 2.0 Google Doc
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+# Write the content of the suggestion here.
+# Add comments to the suggestion as separate comments in the issue thread.
+
+
+# List the original authors' GitHub handles or names here.
+**Original authors**:


### PR DESCRIPTION
This is just a basic template that would point users toward including suggestions' original authors, when available.

Stems from https://github.com/bids-standard/bids-2-devel/issues/1#issuecomment-667675257.